### PR TITLE
Store the container name of cloud in UFile domain

### DIFF
--- a/grails-app/domain/com/causecode/fileuploader/UFile.groovy
+++ b/grails-app/domain/com/causecode/fileuploader/UFile.groovy
@@ -37,6 +37,7 @@ class UFile implements Serializable {
     String fileGroup
     String name
     String path
+    String containerName // Name of the cloud container.
 
     //Contains calculated hash value of file content
     String checksum
@@ -65,6 +66,7 @@ class UFile implements Serializable {
         dateCreated bindable: false
         lastUpdated bindable: false
         envName bindable: false
+        containerName bindable: false
     }
 
     static mapping = {
@@ -75,6 +77,11 @@ class UFile implements Serializable {
         checksum index: true
         //Index on checksumAlgorithm
         checksumAlgorithm index: true
+    }
+
+    // Store the container name of cloud in the {@link UFile} instance.
+    def beforeInsert() {
+        this.containerName = this.getContainer()
     }
 
     def afterDelete() {


### PR DESCRIPTION
#### Problem

[comment]: # (A brief description of the problem being solved, including motivation and context of PR)
* Get the details of bucket in which file belongs. It also makes easy to perform UFile domain related operations.

#### Solution / Approach

[comment]: # (A brief description of the solution and approach. Include which files to start with, and intended flow of code review)
* Add a field `containerName` in the UFile domain.

#### Test Procedures

[comment]: # (How did you manually test)
* Upload a new file and its instance in the database should also contain `containerName`.